### PR TITLE
💥 [Emitten] Improve listener argument typing

### DIFF
--- a/.changeset/flat-hairs-judge.md
+++ b/.changeset/flat-hairs-judge.md
@@ -1,0 +1,6 @@
+---
+'emitten': minor
+---
+
+- Prefer variadic listener arguments.
+- Remove `.disposable()` method. Now returning the `dispose` function from `.on()`.

--- a/README.md
+++ b/README.md
@@ -16,17 +16,20 @@ Import and start emit’in!
 
 ```ts
 import {Emitten} from 'emitten';
+import type {EmittenMap} from 'emitten';
 
-interface EventMap {
-  change: string;
-  count: number;
-  other: string[];
-}
+type EventMap = EmittenMap & {
+  change(value: string): void;
+  count(value?: number): void;
+  collect(...values: boolean[]): void;
+};
 
 const myEmitter = new Emitten<EventMap>();
 
-myEmitter.on('change', someFunction);
+const dispose = myEmitter.on('change', (value) => {});
 myEmitter.emit('change', 'Hello world');
+
+dispose();
 ```
 
 For more guidance, please take a look at the [`Examples document`](./docs/examples.md).

--- a/README.md
+++ b/README.md
@@ -16,9 +16,8 @@ Import and start emit’in!
 
 ```ts
 import {Emitten} from 'emitten';
-import type {EmittenMap} from 'emitten';
 
-type EventMap = EmittenMap & {
+type EventMap = {
   change(value: string): void;
   count(value?: number): void;
   collect(...values: boolean[]): void;

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -9,83 +9,102 @@ The easiest way to use `Emitten` is to simply instantiate it and begin wiring up
 For this use case, you most likely want to use `Emitten` instead of `EmittenProtected`. If you instantiate using `EmittenProtected`, you will not be able to call any `protected` members.
 
 ```ts
-import {Emitten} from 'emitten';
+// Start by defining your “event map”.
+// This is an `interface` comprised of
+// `eventName -> listener function`.
+// This type MUST EXTEND `EmittenMap`.
 
-// The “event map” that you define.
-// This is an object of `eventName` keys,
-// and their `callback argument` value.
-interface EventMap {
-  change: string;
-  count: number;
-  other: string[];
-}
+type EventMap = EmittenMap & {
+  change(value: string): void;
+  count(value?: number): void;
+  collect(values: boolean[]): void;
+  rest(value: string, ...more: string[]): void;
+  nothing(): void;
+};
 
 // Instantiate a new instance, passing the `EventMap`
 // as the generic to `Emitten`.
 const myEvents = new Emitten<EventMap>();
 
-// Define your callbacks...
-// `value` needs to be “optional”.
+// Define your callback functions.
 
-function handleChange(value?: EventMap['change']) {
+// If needed, you can grab the `listener` argument
+// types by using the TypeScript `Parameters`
+// utility and manually selecting the value
+// by `key + index`. Example:
+type ChangeValue = Parameters<EventMap['change']>[0];
+
+function handleChange(value: ChangeValue) {
   console.log('change', value);
 }
 
-function handleCount(value?: EventMap['count']) {
+function handleCount(value = 0) {
   console.log('count', value);
 }
 
-function handleOther(value?: EventMap['other']) {
-  console.log('other', value);
+function handleCollect(values: boolean[]) {
+  console.log('collect', values);
 }
 
-// Subscribe to the `change` and `count` events.
+// Subscribe to the events you are interested in.
 myEvents.on('change', handleChange);
 myEvents.on('count', handleCount);
 
-// Not recommended to pass anonymous functions!
-// In order to remove this, you will have to call `.empty()`.
-myEvents.on('count', (value) => console.log('2nd count listener', value));
-
-// Alternatively, you can register a listener using
-// `.disposable()`, which will return the corresponding
-// `.off()` method to make removal easier.
-const registered = myEvents.disposable('count', (value) =>
-  console.log('An anonymous function', value),
-);
-
-// The listener can now be removed by calling the return value.
-registered();
-
-// Subscribe to the `other` event only once. The
+// Subscribe to the `collect` event only once. The
 // subscription will be automatically removed upon `emit`.
-myEvents.once('other', handleOther);
+myEvents.once('collect', handleCollect);
 
-// The `value` argument of `emit` is optional
-// (can be `undefined`) and therefor is not
-// required to `emit` an `event`.
-myEvents.emit('change');
-myEvents.emit('count');
-myEvents.emit('other');
+// It is not recommended to pass anonymous functions
+// like in the example below. In order to remove this,
+// you would have to call `.empty()` and clear out
+// all of the events from this instance.
+myEvents.on('count', (value) => {
+  console.log('2nd count listener', value);
+});
+
+// However, you can register a listener using
+// `.disposable()`, which will return the corresponding
+// `.off()` method to make removal easier!
+const disposeRest = myEvents.disposable('rest', (value, ...more) => {
+  console.log('An anonymous `rest` function', value, ...more);
+});
+
+// Lastly, an example of `listener` without any arguments.
+// Since `once` will remove itself after `emit`, it is
+// fine to pass anonymous functions.
+myEvents.once('nothing', () => {
+  console.log('Nothing!');
+});
+
+// We can now start emitting events!
 
 myEvents.emit('change', 'hello');
-myEvents.emit('count', 2);
+myEvents.emit('count');
+myEvents.emit('count', 1);
+myEvents.emit('collect', [true, false, true]);
+myEvents.emit('rest', '1st string', '2nd string', '3rd string');
+myEvents.emit('nothing');
 
-// Since the `handleOther` function was registered with `.once()`,
-// this 2nd call to `.emit('other')` will not be received by anything.
-myEvents.emit('other', ['one', 'two', 'three']);
+// Since the `handleCollect` function was registered with `.once()`,
+// this 2nd call to `.emit('collect')` will not be received by anything.
+myEvents.emit('collect', [true, false, true]);
 
 // Attempting to `emit` an `eventName` that does
 // not exist in the `EventMap`, or passing a `value`
 // that is not compatible with the defined event’s
 // value type, will result in a TypeScript error.
 myEvents.emit('nope');
-myEvents.emit('count', 'one');
+myEvents.emit('change', '1st string', '2nd string');
+myEvents.emit('count', true);
+myEvents.emit('nothing', 'something');
 
-// Can manually remove an individual listener.
+// Can manually remove an individual listener by reference.
 myEvents.off('change', handleChange);
 
-// Or can completely empty out all events + listeners.
+// Or manually call a returned `dispose` function.
+disposeRest();
+
+// Or you can completely empty out all events + listeners.
 myEvents.empty();
 ```
 
@@ -94,10 +113,10 @@ myEvents.empty();
 Since “derived classes” have access to the `protected` members of their “base class”, you can utilize `EmittenProtected` to both utilize `protected` members while also keeping them `protected` when instantiating your new `class`.
 
 ```ts
-interface ExtendedEventMap {
-  custom: string;
-  other: number;
-}
+type ExtendedEventMap = EmittenMap & {
+  custom(value: string): void;
+  other(value: number): void;
+};
 
 class ExtendedEmitten extends EmittenProtected<ExtendedEventMap> {
   // If required, you can selectively expose any `protected` members.
@@ -110,25 +129,25 @@ class ExtendedEmitten extends EmittenProtected<ExtendedEventMap> {
     return super.getActiveEvents();
   }
 
-  public on<TKey extends keyof ExtendedEventMap>(
-    eventName: TKey,
-    listener: EmittenListener<ExtendedEventMap[TKey]>,
+  public on<K extends keyof ExtendedEventMap>(
+    eventName: K,
+    listener: ExtendedEventMap[K],
   ) {
     super.on(eventName, listener);
   }
 
-  public off<TKey extends keyof ExtendedEventMap>(
-    eventName: TKey,
-    listener: EmittenListener<ExtendedEventMap[TKey]>,
+  public off<K extends keyof ExtendedEventMap>(
+    eventName: K,
+    listener: ExtendedEventMap[K],
   ) {
     super.off(eventName, listener);
   }
 
-  public emit<TKey extends keyof ExtendedEventMap>(
-    eventName: TKey,
-    value?: ExtendedEventMap[TKey],
+  public emit<K extends keyof ExtendedEventMap>(
+    eventName: K,
+    ...values: Parameters<ExtendedEventMap[K]>
   ) {
-    super.emit(eventName, value);
+    super.emit(eventName, ...values);
   }
 
   report() {
@@ -138,15 +157,15 @@ class ExtendedEmitten extends EmittenProtected<ExtendedEventMap> {
 
 const extended = new ExtendedEmitten();
 
-// Since we converted both `.on()` and `.emit()` to be `public`,
-// we can safely call them on the instance.
-
-extended.on('custom', (value) => console.log('value', value));
-extended.emit('custom', 'hello');
+extended.on('custom', (value) => {
+  console.log('value', value);
+});
 
 extended.report();
 
-// However, we did not expose `.empty()`, so we will
+extended.emit('custom', 'hello');
+
+// We did not expose `.empty()`, so we will
 // receive a TypeScript error attempting to call this.
 extended.empty();
 ```
@@ -156,32 +175,34 @@ extended.empty();
 We can of course create classes that do not extend `Emitten`, and instead create a `private` instance of `Emitten` to perform event actions on.
 
 ```ts
-function assertValue(value?: string): value is string {
-  return Boolean(value?.length);
-}
+type AnotherMap = EmittenMap & {
+  change(value: string): void;
+  count(value?: number): void;
+  names(value: string, ...more: string[]): void;
+};
 
 class AnotherExample {
   #id = 'DefaultId';
   #counter = 0;
-  #names: EventMap['other'] = [];
+  #names: string[] = [];
 
-  // Would not be able to call `.emit()` or `.empty()`
-  // if we had used `Emitten`.
-  #exampleEvents = new Emitten<EventMap>();
+  // Would not be able to call any methods
+  // if we had used `EmittenProtected`.
+  #events = new Emitten<EventMap>();
 
-  #handleChange: (value?: EventMap['change']) => void;
-  #handleCount: (value?: EventMap['count']) => void;
-  #handleOther: (value?: EventMap['other']) => void;
+  #handleChange: AnotherMap['change'];
+  #handleCount: AnotherMap['count'];
+  #handleNames: AnotherMap['names'];
 
   constructor() {
     this.#handleChange = (value) => {
-      this.#id = assertValue(value) ? value : this.#id;
+      this.#id = value.length > 0 ? value : this.#id;
       console.log('#handleChange', value);
     };
 
     this.#handleCount = (value) => {
       if (this.#counter >= 4) {
-        this.#exampleEvents.off('count', this.#handleCount);
+        this.#events.off('count', this.#handleCount);
       } else {
         this.#counter++;
       }
@@ -189,21 +210,22 @@ class AnotherExample {
       console.log('#handleCount', value);
     };
 
-    this.#handleOther = (value) => {
-      this.#names = value ? [...this.#names, ...value] : this.#names;
-      console.log('#handleOther', value);
+    this.#handleNames = (value, ...rest) => {
+      const collected = [value, ...rest];
+      this.#names = [...this.#names, ...collected];
+      console.log('#handleNames', collected);
     };
 
-    this.#exampleEvents.on('change', this.#handleChange);
+    this.#events.on('change', this.#handleChange);
 
     // Registering the same `listener` on the same `event`
     // will not create duplicate entries. When `count` is
     // emitted, we will see only one call to `#handleCount()`.
-    this.#exampleEvents.on('count', this.#handleCount);
-    this.#exampleEvents.on('count', this.#handleCount);
-    this.#exampleEvents.on('count', this.#handleCount);
+    this.#events.on('count', this.#handleCount);
+    this.#events.on('count', this.#handleCount);
+    this.#events.on('count', this.#handleCount);
 
-    this.#exampleEvents.on('other', this.#handleOther);
+    this.#events.on('names', this.#handleNames);
   }
 
   get currentId() {
@@ -219,24 +241,24 @@ class AnotherExample {
   }
 
   get events() {
-    return this.#exampleEvents.activeEvents;
+    return this.#events.activeEvents;
   }
 
   change(value: string) {
-    this.#exampleEvents.emit('change', value);
+    this.#events.emit('change', value);
   }
 
   count() {
-    this.#exampleEvents.emit('count', this.#counter);
+    this.#events.emit('count', this.#counter);
   }
 
-  other(...values: EventMap['other']) {
-    this.#exampleEvents.emit('other', values);
+  names(value: string, ...more: string[]) {
+    this.#events.emit('names', value, ...more);
   }
 
   destroy() {
     console.log('Removing all listeners from newThinger...');
-    this.#exampleEvents.empty();
+    this.#events.empty();
   }
 }
 
@@ -255,7 +277,7 @@ document.addEventListener('click', () => {
 
   myExample.change('clicked');
   myExample.count();
-  myExample.other(...otherData);
+  myExample.names(...otherData);
 
   if (myExample.currentOther.length > otherCollection.length) {
     console.log('Events BEFORE emptying:', myExample.events);

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -10,17 +10,33 @@ For this use case, you most likely want to use `Emitten` instead of `EmittenProt
 
 ```ts
 // Start by defining your “event map”.
-// This is an `interface` comprised of
+// This is a `Record` type comprised of
 // `eventName -> listener function`.
-// This type MUST EXTEND `EmittenMap`.
 
-type EventMap = EmittenMap & {
+// It is recommended to use the `type` keyword instead of `interface`!
+// There is an important distinction... using `type`, you will:
+// 1. Not need to `extend` from `EmittenMap`.
+// 2. Automatically receive type-safety for `event` names.
+
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+type EventMap = {
   change(value: string): void;
   count(value?: number): void;
   collect(values: boolean[]): void;
   rest(required: string, ...optional: string[]): void;
   nothing(): void;
 };
+
+// If you do prefer using `interface`, just know that:
+// 1. You MUST `extend` from `EmittenMap`.
+// 2. You will NOT receive type-safety for `event` names.
+export interface AltMap extends EmittenMap {
+  change(value: string): void;
+  count(value?: number): void;
+  collect(values: boolean[]): void;
+  rest(required: string, ...optional: string[]): void;
+  nothing(): void;
+}
 
 // Instantiate a new instance, passing the `EventMap`
 // as the generic to `Emitten`.
@@ -93,7 +109,10 @@ myEvents.emit('collect', [true, false, true]);
 // not exist in the `EventMap`, or passing a `value`
 // that is not compatible with the defined event’s
 // value type, will result in a TypeScript error.
+myEvents.on('nope', () => {});
+myEvents.off('nope', () => {});
 myEvents.emit('nope');
+
 myEvents.emit('change', '1st string', '2nd string');
 myEvents.emit('count', true);
 myEvents.emit('rest');
@@ -114,7 +133,8 @@ myEvents.empty();
 Since “derived classes” have access to the `protected` members of their “base class”, you can utilize `EmittenProtected` to both utilize `protected` members while also keeping them `protected` when instantiating your new `class`.
 
 ```ts
-type ExtendedEventMap = EmittenMap & {
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+type ExtendedEventMap = {
   custom(value: string): void;
   other(value: number): void;
 };
@@ -171,7 +191,8 @@ extended.empty();
 We can of course create classes that do not extend `Emitten`, and instead create a `private` instance of `Emitten` to perform event actions on.
 
 ```ts
-type AnotherMap = EmittenMap & {
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+type AnotherMap = {
   change(value: string): void;
   count(value?: number): void;
   names(...values: string[]): void;

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -62,10 +62,10 @@ myEvents.on('count', (value) => {
   console.log('2nd count listener', value);
 });
 
-// However, you can register a listener using
-// `.disposable()`, which will return the corresponding
-// `.off()` method to make removal easier!
-const disposeRest = myEvents.disposable('rest', (required, ...optional) => {
+// However, `.on()` will return the corresponding “dispose”
+// for that listener. Simply capture the “disposable” and
+// call it when you are ready to remove that listener.
+const disposeRest = myEvents.on('rest', (required, ...optional) => {
   console.log('An anonymous `rest` function', required, ...optional);
 });
 
@@ -128,7 +128,8 @@ class ExtendedEmitten extends EmittenProtected<ExtendedEventMap> {
     eventName: K,
     listener: ExtendedEventMap[K],
   ) {
-    super.on(eventName, listener);
+    const dispose = super.on(eventName, listener);
+    return dispose;
   }
 
   public off<K extends keyof ExtendedEventMap>(

--- a/docs/future.md
+++ b/docs/future.md
@@ -12,10 +12,6 @@ I seem to have gotten close to successfully typing the `...values` argument for 
   - `Type 'EventMap' does not satisfy the constraint 'EmittenMap'.`
   - `Index signature for type 'string' is missing in type 'EventMap'`
 
-**Figure out how to limit the number of `values`:**
-
-This _could be resolved_ once I figure out the error above. But currently - while I do get some better typing on my listener arguments - I seem to get inconsistent type complains when passing arguments:
-
 ```ts
 interface EventMap {
   hello(value: string): void;
@@ -24,16 +20,9 @@ interface EventMap {
   single(value?: boolean): void;
   all(): void;
 }
-
-// Double check that this works as expected.
-menuEvents.on('hello', (one, two, three) => {});
-
-// The extra arguments may not always get reported?
-menuEvents.emit('hello', 'Hello World', 123);
-menuEvents.emit('multi', '1', 2, false, 'hello', true);
 ```
 
-But, it might be that using a `type` instead of `interface` will work:
+At the moment, I need to make sure the `Generic` passed to `Emitten` always `extends EmittenMap`:
 
 ```ts
 type EventMap = EmittenMap & {
@@ -46,6 +35,8 @@ type EventMap = EmittenMap & {
 
 const menuEvents = new Emitten<EventMap>();
 ```
+
+It would be nice if I could avoid this.
 
 ## No dynamic delete
 
@@ -68,3 +59,7 @@ I can probably jsut return the `.off` within `.on`... I don't think we need a se
 ## Revisit loose equality checks
 
 There are some `null` checks in `EmittenProtected` I wan't to more thoroughly check.
+
+## Reconsider some TSConfig/ESLint
+
+I already know that I want to remove the `@typescript-eslint/no-dynamic-delete` fron `.eslintrc`. Additionally, I might want to disable `@typescript-eslint/strict-boolean-expressions`.

--- a/docs/future.md
+++ b/docs/future.md
@@ -2,11 +2,7 @@
 
 This document describes some of the follow-up tasks I have in mind.
 
-## Stricter callback argument
-
-I seem to have gotten close to successfully typing the `...values` argument for `EmittenListener`, but I am still failing to:
-
-**Figure out how to correctly type a custom `EventMap`:**
+## correctly type a custom `EventMap`
 
 - Currently, I get an error on the generic for `new Emitten<EventMap>()`:
   - `Type 'EventMap' does not satisfy the constraint 'EmittenMap'.`
@@ -38,10 +34,6 @@ const menuEvents = new Emitten<EventMap>();
 
 It would be nice if I could avoid this.
 
-## No dynamic delete
-
-I got sloppy and used the `delete` keyword... I need to remove the `@typescript-eslint/no-dynamic-delete` override and filter that `object` properly.
-
 ## Write tests
 
 I have not actually authored any tests yet... but I plan to use `vitest` once Iâ€™m ready.
@@ -51,6 +43,10 @@ I have not actually authored any tests yet... but I plan to use `vitest` once Iâ
 I might need to add `typescript` as a peer dep.
 
 Also, `@changesets` should be moved to `devDeps`.
+
+## No dynamic delete
+
+I got sloppy and used the `delete` keyword... I need to remove the `@typescript-eslint/no-dynamic-delete` override and filter that `object` properly.
 
 ## Revisit loose equality checks
 

--- a/docs/future.md
+++ b/docs/future.md
@@ -4,45 +4,48 @@ This document describes some of the follow-up tasks I have in mind.
 
 ## Stricter callback argument
 
-It would be nice to make it so the `value` argument isn't optional.
+I seem to have gotten close to successfully typing the `...values` argument for `EmittenListener`, but I am still failing to:
+
+**Figure out how to correctly type a custom `EventMap`:**
+
+- Currently, I get an error on the generic for `new Emitten<EventMap>()`:
+  - `Type 'EventMap' does not satisfy the constraint 'EmittenMap'.`
+  - `Index signature for type 'string' is missing in type 'EventMap'`
+
+**Figure out how to limit the number of `values`:**
+
+This _could be resolved_ once I figure out the error above. But currently - while I do get some better typing on my listener arguments - I seem to get inconsistent type complains when passing arguments:
 
 ```ts
-// I might register a listener that will ALWAYS
-// pass an argument of a specific type.
-function handleChange(data: SomeObject) {
-  return Object.keys(data);
-}
-
-// I will get a type error here, because `data`
-// was not marked as “optional”.
-myEvents.on('change', handleChange);
-
-// Calling `emit` does not require a 2nd argument.
-myEvents.emit('change');
-```
-
-I would like to find a way to type the `EventMap` generic passed to `Emitten` to that you have more control over how the values are typed.
-
-```ts
-// Not sure if the `EmittenListener` type needs to change,
-// but it is possible it changes to something like:
-type EmittenListener<T> = (...values: T[]) => void;
-
-// Then `EventMap` can maybe look something like this:
 interface EventMap {
-  change: (value: string, other?: boolean) => void;
-  count: (value: number) => void;
-  other: (value: string[]) => void;
+  hello(value: string): void;
+  count(value: number): void;
+  multi(one: string, two: number, three?: boolean): void;
+  single(value?: boolean): void;
+  all(): void;
 }
 
-// Then the `emit` method maybe looks something like this:
-function emit<TKey extends keyof T>(
-  eventName: TKey,
-  value: Parameters<T[TKey]>,
-) {}
+// Double check that this works as expected.
+menuEvents.on('hello', (one, two, three) => {});
+
+// The extra arguments may not always get reported?
+menuEvents.emit('hello', 'Hello World', 123);
+menuEvents.emit('multi', '1', 2, false, 'hello', true);
 ```
 
-This will require some experimentation.
+But, it might be that using a `type` instead of `interface` will work:
+
+```ts
+type EventMap = EmittenMap & {
+  hello(value: string): void;
+  count(value: number): void;
+  multi(one: string, two: number, three?: boolean): void;
+  single(value?: boolean): void;
+  all(): void;
+};
+
+const menuEvents = new Emitten<EventMap>();
+```
 
 ## No dynamic delete
 

--- a/docs/future.md
+++ b/docs/future.md
@@ -2,38 +2,6 @@
 
 This document describes some of the follow-up tasks I have in mind.
 
-## correctly type a custom `EventMap`
-
-- Currently, I get an error on the generic for `new Emitten<EventMap>()`:
-  - `Type 'EventMap' does not satisfy the constraint 'EmittenMap'.`
-  - `Index signature for type 'string' is missing in type 'EventMap'`
-
-```ts
-interface EventMap {
-  hello(value: string): void;
-  count(value: number): void;
-  multi(one: string, two: number, three?: boolean): void;
-  single(value?: boolean): void;
-  all(): void;
-}
-```
-
-At the moment, I need to make sure the `Generic` passed to `Emitten` always `extends EmittenMap`:
-
-```ts
-type EventMap = EmittenMap & {
-  hello(value: string): void;
-  count(value: number): void;
-  multi(one: string, two: number, three?: boolean): void;
-  single(value?: boolean): void;
-  all(): void;
-};
-
-const menuEvents = new Emitten<EventMap>();
-```
-
-It would be nice if I could avoid this.
-
 ## Write tests
 
 I have not actually authored any tests yet... but I plan to use `vitest` once I’m ready.

--- a/docs/future.md
+++ b/docs/future.md
@@ -52,10 +52,6 @@ I might need to add `typescript` as a peer dep.
 
 Also, `@changesets` should be moved to `devDeps`.
 
-## Remove `disposable` in favour of `on`
-
-I can probably jsut return the `.off` within `.on`... I don't think we need a separate `disposable` method.
-
 ## Revisit loose equality checks
 
 There are some `null` checks in `EmittenProtected` I wan't to more thoroughly check.

--- a/docs/future.md
+++ b/docs/future.md
@@ -58,3 +58,13 @@ I have not actually authored any tests yet... but I plan to use `vitest` once Iâ
 ## Figure out the right `peerDependencies`
 
 I might need to add `typescript` as a peer dep.
+
+Also, `@changesets` should be moved to `devDeps`.
+
+## Remove `disposable` in favour of `on`
+
+I can probably jsut return the `.off` within `.on`... I don't think we need a separate `disposable` method.
+
+## Revisit loose equality checks
+
+There are some `null` checks in `EmittenProtected` I wan't to more thoroughly check.

--- a/src/Emitten.ts
+++ b/src/Emitten.ts
@@ -11,16 +11,12 @@ export class Emitten<T extends EmittenMap> extends EmittenProtected<T> {
   }
 
   public on<K extends keyof T>(eventName: K, listener: T[K]) {
-    super.on(eventName, listener);
+    const dispose = super.on(eventName, listener);
+    return dispose;
   }
 
   public once<K extends keyof T>(eventName: K, listener: T[K]) {
     super.once(eventName, listener);
-  }
-
-  public disposable<K extends keyof T>(eventName: K, listener: T[K]) {
-    const result = super.disposable(eventName, listener);
-    return result;
   }
 
   public emit<K extends keyof T>(eventName: K, ...values: Parameters<T[K]>) {

--- a/src/Emitten.ts
+++ b/src/Emitten.ts
@@ -1,46 +1,29 @@
 import {EmittenProtected} from './EmittenProtected';
 import type {EmittenMap} from './types';
 
-export class Emitten<
-  TEventMap extends EmittenMap,
-> extends EmittenProtected<TEventMap> {
+export class Emitten<T extends EmittenMap> extends EmittenProtected<T> {
   public get activeEvents() {
     return super.getActiveEvents();
   }
 
-  public off<TKey extends keyof TEventMap>(
-    eventName: TKey,
-    listener: TEventMap[TKey],
-  ) {
+  public off<K extends keyof T>(eventName: K, listener: T[K]) {
     super.off(eventName, listener);
   }
 
-  public on<TKey extends keyof TEventMap>(
-    eventName: TKey,
-    listener: TEventMap[TKey],
-  ) {
+  public on<K extends keyof T>(eventName: K, listener: T[K]) {
     super.on(eventName, listener);
   }
 
-  public once<TKey extends keyof TEventMap>(
-    eventName: TKey,
-    listener: TEventMap[TKey],
-  ) {
+  public once<K extends keyof T>(eventName: K, listener: T[K]) {
     super.once(eventName, listener);
   }
 
-  public disposable<TKey extends keyof TEventMap>(
-    eventName: TKey,
-    listener: TEventMap[TKey],
-  ) {
+  public disposable<K extends keyof T>(eventName: K, listener: T[K]) {
     const result = super.disposable(eventName, listener);
     return result;
   }
 
-  public emit<TKey extends keyof TEventMap>(
-    eventName: TKey,
-    ...values: Parameters<TEventMap[TKey]>
-  ) {
+  public emit<K extends keyof T>(eventName: K, ...values: Parameters<T[K]>) {
     super.emit(eventName, ...values);
   }
 

--- a/src/Emitten.ts
+++ b/src/Emitten.ts
@@ -1,35 +1,37 @@
 import {EmittenProtected} from './EmittenProtected';
-import type {EmittenListener} from './types';
+import type {EmittenMap} from './types';
 
-export class Emitten<TEventMap> extends EmittenProtected<TEventMap> {
+export class Emitten<
+  TEventMap extends EmittenMap,
+> extends EmittenProtected<TEventMap> {
   public get activeEvents() {
     return super.getActiveEvents();
   }
 
   public off<TKey extends keyof TEventMap>(
     eventName: TKey,
-    listener: EmittenListener<TEventMap[TKey]>,
+    listener: TEventMap[TKey],
   ) {
     super.off(eventName, listener);
   }
 
   public on<TKey extends keyof TEventMap>(
     eventName: TKey,
-    listener: EmittenListener<TEventMap[TKey]>,
+    listener: TEventMap[TKey],
   ) {
     super.on(eventName, listener);
   }
 
   public once<TKey extends keyof TEventMap>(
     eventName: TKey,
-    listener: EmittenListener<TEventMap[TKey]>,
+    listener: TEventMap[TKey],
   ) {
     super.once(eventName, listener);
   }
 
   public disposable<TKey extends keyof TEventMap>(
     eventName: TKey,
-    listener: EmittenListener<TEventMap[TKey]>,
+    listener: TEventMap[TKey],
   ) {
     const result = super.disposable(eventName, listener);
     return result;
@@ -37,9 +39,9 @@ export class Emitten<TEventMap> extends EmittenProtected<TEventMap> {
 
   public emit<TKey extends keyof TEventMap>(
     eventName: TKey,
-    value?: TEventMap[TKey],
+    ...values: Parameters<TEventMap[TKey]>
   ) {
-    super.emit(eventName, value);
+    super.emit(eventName, ...values);
   }
 
   public empty() {

--- a/src/Emitten.ts
+++ b/src/Emitten.ts
@@ -3,7 +3,7 @@ import type {EmittenMap} from './types';
 
 export class Emitten<T extends EmittenMap> extends EmittenProtected<T> {
   public get activeEvents() {
-    return super.getActiveEvents();
+    return this.getActiveEvents();
   }
 
   public off<K extends keyof T>(eventName: K, listener: T[K]) {

--- a/src/EmittenProtected.ts
+++ b/src/EmittenProtected.ts
@@ -40,6 +40,10 @@ export class EmittenProtected<T extends EmittenMap> {
     }
 
     this.#multiLibrary[eventName]?.add(listener);
+
+    return () => {
+      this.off(eventName, listener);
+    };
   }
 
   protected once<K extends keyof T>(eventName: K, listener: T[K]) {
@@ -48,14 +52,6 @@ export class EmittenProtected<T extends EmittenMap> {
     }
 
     this.#singleLibrary[eventName]?.add(listener);
-  }
-
-  protected disposable<K extends keyof T>(eventName: K, listener: T[K]) {
-    this.on(eventName, listener);
-
-    return () => {
-      this.off(eventName, listener);
-    };
   }
 
   protected emit<K extends keyof T>(eventName: K, ...values: Parameters<T[K]>) {

--- a/src/EmittenProtected.ts
+++ b/src/EmittenProtected.ts
@@ -15,8 +15,9 @@ export class EmittenProtected<T extends EmittenMap> {
     const singleKeys = Object.keys(this.#singleLibrary);
 
     const dedupedKeys = new Set([...multiKeys, ...singleKeys]);
+    const result: Array<keyof T> = [...dedupedKeys];
 
-    return [...dedupedKeys];
+    return result;
   }
 
   protected off<K extends keyof T>(eventName: K, listener: T[K]) {

--- a/src/EmittenProtected.ts
+++ b/src/EmittenProtected.ts
@@ -1,8 +1,8 @@
 import type {EmittenMap, EmittenLibraryPartial} from './types';
 
-export class EmittenProtected<TEventMap extends EmittenMap> {
-  #multiLibrary: EmittenLibraryPartial<TEventMap> = {};
-  #singleLibrary: EmittenLibraryPartial<TEventMap> = {};
+export class EmittenProtected<T extends EmittenMap> {
+  #multiLibrary: EmittenLibraryPartial<T> = {};
+  #singleLibrary: EmittenLibraryPartial<T> = {};
 
   protected get activeEvents() {
     // This redundant getter + method are required
@@ -19,10 +19,7 @@ export class EmittenProtected<TEventMap extends EmittenMap> {
     return [...dedupedKeys];
   }
 
-  protected off<TKey extends keyof TEventMap>(
-    eventName: TKey,
-    listener: TEventMap[TKey],
-  ) {
+  protected off<K extends keyof T>(eventName: K, listener: T[K]) {
     const multiSet = this.#multiLibrary[eventName];
     const singleSet = this.#singleLibrary[eventName];
 
@@ -37,10 +34,7 @@ export class EmittenProtected<TEventMap extends EmittenMap> {
     }
   }
 
-  protected on<TKey extends keyof TEventMap>(
-    eventName: TKey,
-    listener: TEventMap[TKey],
-  ) {
+  protected on<K extends keyof T>(eventName: K, listener: T[K]) {
     if (this.#multiLibrary[eventName] == null) {
       this.#multiLibrary[eventName] = new Set();
     }
@@ -48,10 +42,7 @@ export class EmittenProtected<TEventMap extends EmittenMap> {
     this.#multiLibrary[eventName]?.add(listener);
   }
 
-  protected once<TKey extends keyof TEventMap>(
-    eventName: TKey,
-    listener: TEventMap[TKey],
-  ) {
+  protected once<K extends keyof T>(eventName: K, listener: T[K]) {
     if (this.#singleLibrary[eventName] == null) {
       this.#singleLibrary[eventName] = new Set();
     }
@@ -59,10 +50,7 @@ export class EmittenProtected<TEventMap extends EmittenMap> {
     this.#singleLibrary[eventName]?.add(listener);
   }
 
-  protected disposable<TKey extends keyof TEventMap>(
-    eventName: TKey,
-    listener: TEventMap[TKey],
-  ) {
+  protected disposable<K extends keyof T>(eventName: K, listener: T[K]) {
     this.on(eventName, listener);
 
     return () => {
@@ -70,10 +58,7 @@ export class EmittenProtected<TEventMap extends EmittenMap> {
     };
   }
 
-  protected emit<TKey extends keyof TEventMap>(
-    eventName: TKey,
-    ...values: Parameters<TEventMap[TKey]>
-  ) {
+  protected emit<K extends keyof T>(eventName: K, ...values: Parameters<T[K]>) {
     const multiSet = this.#multiLibrary[eventName];
     const singleSet = this.#singleLibrary[eventName];
 
@@ -93,7 +78,7 @@ export class EmittenProtected<TEventMap extends EmittenMap> {
     this.#every(this.#singleLibrary);
   }
 
-  #every = (library: EmittenLibraryPartial<TEventMap>) => {
+  #every = (library: EmittenLibraryPartial<T>) => {
     for (const eventName in library) {
       if (Object.hasOwn(library, eventName)) {
         library[eventName]?.forEach((listener) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,10 @@
 export {Emitten} from './Emitten';
 export {EmittenProtected} from './EmittenProtected';
 
-export type {EmittenListener, EmittenLibrary} from './types';
+export type {
+  EmittenKey,
+  EmittenListener,
+  EmittenMap,
+  EmittenLibrary,
+  EmittenLibraryPartial,
+} from './types';

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,12 @@
-export type EmittenListener<TValue> = (value?: TValue) => void;
+export type EmittenKey = string | symbol;
+export type EmittenListener<TValue = unknown[]> = (...values: TValue[]) => void;
+export type EmittenMap = Record<EmittenKey, EmittenListener>;
 
-export type EmittenLibrary<TEventMap> = {
-  [event in keyof TEventMap]?: Set<EmittenListener<TEventMap[event]>>;
-};
+export type EmittenLibrary<TEventMap> = Record<
+  keyof TEventMap,
+  Set<TEventMap[keyof TEventMap]>
+>;
+
+export type EmittenLibraryPartial<TEventMap> = Partial<
+  EmittenLibrary<TEventMap>
+>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,8 @@
 export type EmittenKey = string | symbol;
-export type EmittenListener<V = unknown[]> = (...values: V[]) => void;
+export type EmittenListener<V extends readonly unknown[] = any[]> = (
+  ...values: V
+) => void;
+
 export type EmittenMap = Record<EmittenKey, EmittenListener>;
 
 export type EmittenLibrary<T> = Record<keyof T, Set<T[keyof T]>>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,12 +1,6 @@
 export type EmittenKey = string | symbol;
-export type EmittenListener<TValue = unknown[]> = (...values: TValue[]) => void;
+export type EmittenListener<V = unknown[]> = (...values: V[]) => void;
 export type EmittenMap = Record<EmittenKey, EmittenListener>;
 
-export type EmittenLibrary<TEventMap> = Record<
-  keyof TEventMap,
-  Set<TEventMap[keyof TEventMap]>
->;
-
-export type EmittenLibraryPartial<TEventMap> = Partial<
-  EmittenLibrary<TEventMap>
->;
+export type EmittenLibrary<T> = Record<keyof T, Set<T[keyof T]>>;
+export type EmittenLibraryPartial<T> = Partial<EmittenLibrary<T>>;


### PR DESCRIPTION
This PR attempts to improve the overall typing to allow for "variadic arguments".

**Changed in this PR:**

- Revised all the types to support `variadic arguments`.
  - You now define your custom `EventMap` as `{eventName: (arg1: string, arg2: number, ...etc: any[]) => void}`
  - You should now have type-safety for event names and arguments.
- Removed `.disposable()` method.
  - `.on()` now returns the "disposable".
  - The previous API was redundant, so I've simply merged `disposable + on`.
- Updated documentation to reflect changes.

The new `EventMap` format is slightly awkward... you MUST use `type` instead of `interface`. If using `interface`, `TypeScript` will complain about misalignment with `EmittenMap`. If you then `extend EmittenMap`, you will lose type-safety on event names 🤷 

The `CodeSandbox` where I am testing this is here:
https://codesandbox.io/s/emitten-83hjfs?file=/src/components/Nav/components/Menu/Menu.tsx

Additionally, I found this article to be helpful in validating my expectation to use `Parameters<>`:
https://dawchihliou.github.io/articles/event-bus-for-react

Huge props to [`vera`](https://stackoverflow.com/users/18244921/vera) for helping me resolve the `eventName` type-safety:
https://stackoverflow.com/questions/75289375/typescript-generic-that-ensures-record-key-match
