### PR TITLE
🐛 [Fix] Avoid calling `super` on an accessor

### DIFF
--- a/.changeset/smart-eyes-switch.md
+++ b/.changeset/smart-eyes-switch.md
@@ -1,0 +1,5 @@
+---
+'emitten': minor
+---
+
+Implement a workaround for calling super on an accessor.

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -104,6 +104,12 @@ class ExtendedEmitten extends EmittenProtected<ExtendedEventMap> {
   // Otherwise, if you want all members to be `public`, you can
   // extend the `Emitten` class instead.
 
+  public get activeEvents() {
+    // Must use the `method`, since `super` cannot
+    // be called on an accessor.
+    return super.getActiveEvents();
+  }
+
   public on<TKey extends keyof ExtendedEventMap>(
     eventName: TKey,
     listener: EmittenListener<ExtendedEventMap[TKey]>,

--- a/src/Emitten.ts
+++ b/src/Emitten.ts
@@ -3,7 +3,7 @@ import type {EmittenListener} from './types';
 
 export class Emitten<TEventMap> extends EmittenProtected<TEventMap> {
   public get activeEvents() {
-    return super.activeEvents;
+    return super.getActiveEvents();
   }
 
   public off<TKey extends keyof TEventMap>(

--- a/src/EmittenProtected.ts
+++ b/src/EmittenProtected.ts
@@ -5,6 +5,12 @@ export class EmittenProtected<TEventMap> {
   #singleLibrary: EmittenLibrary<TEventMap> = {};
 
   protected get activeEvents() {
+    // This redundant getter + method are required
+    // because you cannot call `super` on an accessor.
+    return this.getActiveEvents();
+  }
+
+  protected getActiveEvents() {
     const multiKeys = Object.keys(this.#multiLibrary);
     const singleKeys = Object.keys(this.#singleLibrary);
 


### PR DESCRIPTION
There were not any warning about doing this during development... but apparently you cannot call `super.someGetter`.

So I have implemented an unfortunate workaround... now there is a `protected getActiveEvents()` method, which `activeEvents` calls within. Any `class` that `extends` from `EmittenProtected` will need to call `super` on that `method`.