### PR TITLE
♻️ [Emitten] Change `library` from an `object` to a `Map`

### DIFF
--- a/.changeset/orange-bottles-know.md
+++ b/.changeset/orange-bottles-know.md
@@ -1,0 +1,5 @@
+---
+'emitten': patch
+---
+
+Internally, switch the library values from an object to a Map.

--- a/.eslintrc
+++ b/.eslintrc
@@ -12,8 +12,6 @@
   },
   "rules": {
     "prettier/prettier": ["error"],
-    "@typescript-eslint/explicit-function-return-type": "off",
-    "@typescript-eslint/method-signature-style": "off",
-    "@typescript-eslint/no-dynamic-delete": "off"
+    "@typescript-eslint/explicit-function-return-type": "off"
   }
 }

--- a/README.md
+++ b/README.md
@@ -30,10 +30,9 @@ import {Emitten} from 'emitten';
 // Both the `eventName` and the `args` from the `listener` are
 // captured by TypeScript to assert type-safety!
 type EventMap = {
-  change(value: string): void;
-  count(value?: number): void;
-  collect(...values: boolean[]): void;
-  // Method signature style could also look like:
+  change: (value: string) => void;
+  count: (value?: number) => void;
+  collect: (...values: boolean[]) => void;
   other: (required: string, ...optional: string[]) => void;
 };
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -17,25 +17,23 @@ For this use case, you most likely want to use `Emitten` instead of `EmittenProt
 // There is an important distinction... using `type`, you will:
 // 1. Not need to `extend` from `EmittenMap`.
 // 2. Automatically receive type-safety for `event` names.
-
-// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 type EventMap = {
-  change(value: string): void;
-  count(value?: number): void;
-  collect(values: boolean[]): void;
-  rest(required: string, ...optional: string[]): void;
-  nothing(): void;
+  change: (value: string) => void;
+  count: (value?: number) => void;
+  collect: (values: boolean[]) => void;
+  rest: (required: string, ...optional: string[]) => void;
+  nothing: () => void;
 };
 
 // If you do prefer using `interface`, just know that:
 // 1. You MUST `extend` from `EmittenMap`.
 // 2. You will NOT receive type-safety for `event` names.
 export interface AltMap extends EmittenMap {
-  change(value: string): void;
-  count(value?: number): void;
-  collect(values: boolean[]): void;
-  rest(required: string, ...optional: string[]): void;
-  nothing(): void;
+  change: (value: string) => void;
+  count: (value?: number) => void;
+  collect: (values: boolean[]) => void;
+  rest: (required: string, ...optional: string[]) => void;
+  nothing: () => void;
 }
 
 // Instantiate a new instance, passing the `EventMap`
@@ -133,10 +131,9 @@ myEvents.empty();
 Since “derived classes” have access to the `protected` members of their “base class”, you can utilize `EmittenProtected` to both utilize `protected` members while also keeping them `protected` when instantiating your new `class`.
 
 ```ts
-// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 type ExtendedEventMap = {
-  custom(value: string): void;
-  other(value: number): void;
+  custom: (value: string) => void;
+  other: (value: number) => void;
 };
 
 class ExtendedEmitten extends EmittenProtected<ExtendedEventMap> {
@@ -193,12 +190,11 @@ extended.empty();
 We can of course create classes that do not extend `Emitten`, and instead create a `private` instance of `Emitten` to perform event actions on.
 
 ```ts
-// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 type AnotherMap = {
-  change(value: string): void;
-  count(value?: number): void;
-  names(...values: string[]): void;
-  diverse(first: string, second: number, ...last: boolean[]): void;
+  change: (value: string) => void;
+  count: (value?: number) => void;
+  names: (...values: string[]) => void;
+  diverse: (first: string, second: number, ...last: boolean[]) => void;
 };
 
 class AnotherExample {

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,5 +7,4 @@ export type {
   EmittenListener,
   EmittenMap,
   EmittenLibrary,
-  EmittenLibraryPartial,
 } from './types';

--- a/src/tests/Emitten.test.ts
+++ b/src/tests/Emitten.test.ts
@@ -3,10 +3,10 @@ import {Emitten} from '../Emitten';
 
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 type MockEventMap = {
-  foo(value: string): void;
-  bar(value?: number): void;
-  baz(...values: boolean[]): void;
-  qux(required: string, ...optional: string[]): void;
+  foo: (value: string) => void;
+  bar: (value?: number) => void;
+  baz: (...values: boolean[]) => void;
+  qux: (required: string, ...optional: string[]) => void;
 };
 
 describe('Emitten full public members', () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,6 +4,4 @@ export type EmittenListener<V extends readonly unknown[] = any[]> = (
 ) => void;
 
 export type EmittenMap = Record<EmittenKey, EmittenListener>;
-
-export type EmittenLibrary<T> = Record<keyof T, Set<T[keyof T]>>;
-export type EmittenLibraryPartial<T> = Partial<EmittenLibrary<T>>;
+export type EmittenLibrary<T> = Map<keyof T, Set<T[keyof T]>>;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,6 @@
     "noEmit": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "noImplicitAny": true,
     "noImplicitReturns": true,
     "skipLibCheck": true
   },


### PR DESCRIPTION
> This PR refactors some of the internals of `Emitten`.

**Resolves:** https://github.com/beefchimi/emitten/issues/17

**What this PR changes:**

- Removed `EmittenLibraryPartial`.
- Changed `EmittenLibrary` from a `Record<>` to a `Map<>`.
- Updated all of the `EmittenProtected` code to interact with a `Map` instead of an `object`.
- Fully adopted TypeScript `strict` mode by preferring `function property` style _(vs `method` style)_.

All of these changes should be internal only. There should be no difference to the end user.